### PR TITLE
Setup - Remove specific SMRF version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-smrf-dev>=0.11.4,<0.12.0
+smrf-dev
 setuptools_scm<4.2
 xarray>=0.15,<0.16
+


### PR DESCRIPTION
With the UofU install of the model, there is only one corresponding working version of SMRF (the branch HEAD)