### PR TITLE
24hr fix and compression

### DIFF
--- a/awsm/framework/CoreConfig.ini
+++ b/awsm/framework/CoreConfig.ini
@@ -82,12 +82,11 @@ ithreads:       default = 1,
 output_frequency: default = 24,
                 type = int,
                 description = frequency of snow model outputs in hours.
-                This is sepreate from SMRF
+                This is separate from SMRF
 
 daily_folders:  default = False,
                 type = bool,
-                description = seperate daily output folders. Used mainly for
-                shortterm forecasts
+                description = separate daily output folders.
 
 run_for_nsteps: type = int,
                 description = number of timesteps to run iSnobal. This is
@@ -106,11 +105,11 @@ variables:      type = string list,
                 calculated
 
 snow_name:      default = snow,
-                description = prefix of snow ouput file without WYHR
+                description = prefix of snow output file without WYHR
                 extension
 
 em_name:        default = em,
-                description = prefix of energetics ouput file without WYHR
+                description = prefix of energetics output file without WYHR
                 extension
 
 ################################################################################

--- a/awsm/framework/framework.py
+++ b/awsm/framework/framework.py
@@ -394,19 +394,25 @@ class AWSM():
                 'Unknown folder date style: {}'.format(config_value)
             )
 
+    def set_path_output(self):
+        """
+        Set the output path
+        """
+        self.folder_date_stamp = self.format_folder_date_style()
+        self.path_output = os.path.join(
+            self.path_wy,
+            'run{}'.format(self.folder_date_stamp)
+        )
+
+
     def mk_directories(self):
         """
         Create all needed directories starting from the working drive
         """
         self.tmp_log.append('AWSM creating directories')
 
-        self.folder_date_stamp = self.format_folder_date_style()
         self.path_wy = self.basin_path()
-
-        self.path_output = os.path.join(
-            self.path_wy,
-            'run{}'.format(self.folder_date_stamp)
-        )
+        self.set_path_output()
         self.path_log = os.path.join(self.path_output, 'logs')
 
         # name of temporary smrf file to write out

--- a/awsm/framework/framework.py
+++ b/awsm/framework/framework.py
@@ -44,8 +44,8 @@ class AWSM():
                 instance
         """
 
-        self.read_config(config)
         self.testing = testing
+        self.read_config(config)
 
         # create blank log and error log because logger is not initialized yet
         self.tmp_log = []
@@ -225,7 +225,7 @@ class AWSM():
             print("Errors in the config file. "
                   "See configuration status report above.")
             sys.exit()
-        elif len(warnings) > 0:
+        elif len(warnings) > 0 and not self.testing:
             print_config_report(warnings, errors)
 
         self.config = self.ucfg.cfg
@@ -306,9 +306,9 @@ class AWSM():
             #                      'log_forecast_'
             #                      '{}.out'.format(self.folder_date_stamp))
             # else:
-            logfile = \
-                os.path.join(self.path_log,
-                             'log_{}.out'.format(self.folder_date_stamp))
+            logfile = os.path.join(
+                self.path_log, 'log_{}.out'.format(self.folder_date_stamp)
+            )
 
         self.config['awsm system']['log_file'] = logfile
         logger.SMRFLogger(self.config['awsm system'])

--- a/awsm/interface/ipysnobal.py
+++ b/awsm/interface/ipysnobal.py
@@ -507,7 +507,8 @@ class PySnobal():
         else:
             self._logger.debug("  => from first time step")
             self.force = self.awsm.smrf_connector.open_netcdf_files()
-            self.time_step = self.date_time[0]
+            # Load and remove the first step so it won't get run by PySnobal
+            self.time_step = self.date_time.pop(0)
             self.input1 = self.get_timestep_inputs()
 
     def run_ipysnobal(self):
@@ -524,7 +525,7 @@ class PySnobal():
 
         self._logger.info(f"Starting PySnobal for {len(self.date_time)} time steps")
 
-        for self.step_index, self.time_step in enumerate(self.date_time[1:], 1):  # noqa
+        for self.step_index, self.time_step in enumerate(self.date_time, 1):
             self.run_full_timestep()
 
             # if input has run_for_nsteps, make sure not to go past it

--- a/awsm/interface/ipysnobal.py
+++ b/awsm/interface/ipysnobal.py
@@ -445,25 +445,15 @@ class PySnobal():
         """
         Output the time step if on the right frequency.
         """
-        # self._logger.info(f'TIMESTEP INFO: {self.step_index}')
-        self._logger.info(f'TIMESTEP INFO: {self.time_step}')
-        # self._logger.info(f'TIMESTEP INFO: {type(self.time_step)}')
-        self._logger.info(f'TIMESTEP INFO: {self.time_step.hour}')
-        # self._logger.info(f'TIMESTEP INFO: {type(self.time_step.hour)}')
-        # self._logger.info(f'TIMESTEP INFO: {self.data_time_step}')
-        # self._logger.info(f"TIMESTEP INFO: {self.options['output']['frequency']}")
-
         out_freq = (
             self.time_step.hour * self.data_time_step / 3600.0
-        ) % self.options["output"]["frequency"] == 0 # change self.step_index to self.time_step.hour -pk ensures we get data on 0,6,12,18z times
-        self._logger.info(f'TIMESTEP INFO: {out_freq}')
+        ) % self.options["output"]["frequency"] == 0
 
         last_time_step = (
             self.step_index == len(self.options["time"]["date_time"]) - 1
         )
 
         if out_freq or last_time_step:
-
             self._logger.info('iPysnobal outputting {}'.format(self.time_step))
             pysnobal_io.output_timestep(
                 self.output_rec,

--- a/awsm/interface/ipysnobal.py
+++ b/awsm/interface/ipysnobal.py
@@ -444,14 +444,16 @@ class PySnobal():
     def output_timestep(self):
         """
         Output the time step if on the right frequency.
+        Uses the hour of the current processed time step and will always
+        save output at midnight (00:00) due to the multiplication by the hour.
+        Also saves the output of the last time step for reinitialization
+        when started the next time.
         """
         out_freq = (
             self.time_step.hour * self.data_time_step / 3600.0
         ) % self.options["output"]["frequency"] == 0
 
-        last_time_step = (
-            self.step_index == len(self.options["time"]["date_time"]) - 1
-        )
+        last_time_step = self.time_step == self.date_time[-1]
 
         if out_freq or last_time_step:
             self._logger.info('iPysnobal outputting {}'.format(self.time_step))

--- a/awsm/interface/ipysnobal.py
+++ b/awsm/interface/ipysnobal.py
@@ -502,8 +502,11 @@ class PySnobal():
         ):
             self._logger.debug("  => from previous day")
             self.load_previous_day()
+            # Open the files for all future time steps
+            self.force = self.awsm.smrf_connector.open_netcdf_files()
         else:
             self._logger.debug("  => from first time step")
+            self.force = self.awsm.smrf_connector.open_netcdf_files()
             self.time_step = self.date_time[0]
             self.input1 = self.get_timestep_inputs()
 
@@ -515,7 +518,6 @@ class PySnobal():
         self._logger.info("Initializing PySnobal from netcdf files:")
         self.initialize_ipysnobal()
 
-        self.force = self.awsm.smrf_connector.open_netcdf_files()
         self.load_first_timestep_inputs()
 
         self.initialize_updater()

--- a/awsm/interface/ipysnobal.py
+++ b/awsm/interface/ipysnobal.py
@@ -445,10 +445,18 @@ class PySnobal():
         """
         Output the time step if on the right frequency.
         """
+        # self._logger.info(f'TIMESTEP INFO: {self.step_index}')
+        self._logger.info(f'TIMESTEP INFO: {self.time_step}')
+        # self._logger.info(f'TIMESTEP INFO: {type(self.time_step)}')
+        self._logger.info(f'TIMESTEP INFO: {self.time_step.hour}')
+        # self._logger.info(f'TIMESTEP INFO: {type(self.time_step.hour)}')
+        # self._logger.info(f'TIMESTEP INFO: {self.data_time_step}')
+        # self._logger.info(f"TIMESTEP INFO: {self.options['output']['frequency']}")
 
         out_freq = (
-            self.step_index * self.data_time_step / 3600.0
-        ) % self.options["output"]["frequency"] == 0
+            self.time_step.hour * self.data_time_step / 3600.0
+        ) % self.options["output"]["frequency"] == 0 # change self.step_index to self.time_step.hour -pk ensures we get data on 0,6,12,18z times
+        self._logger.info(f'TIMESTEP INFO: {out_freq}')
 
         last_time_step = (
             self.step_index == len(self.options["time"]["date_time"]) - 1

--- a/awsm/interface/ipysnobal.py
+++ b/awsm/interface/ipysnobal.py
@@ -541,6 +541,10 @@ class PySnobal:
         if self.awsm.forcing_data_type == 'netcdf':
             self.awsm.smrf_connector.close_netcdf_files()
 
+        self.options["output"]["snow"].close()
+        self.options["output"]["em"].close()
+        self._logger.debug("PySnobal finished.")
+
     def run_smrf_ipysnobal(self):
         """
         Function to run SMRF and pass outputs in memory to python wrapped

--- a/awsm/interface/pysnobal_io.py
+++ b/awsm/interface/pysnobal_io.py
@@ -55,14 +55,22 @@ def create_netCDF(
 
     # Variables for dimensions
     time = netcdf_file.createVariable(
-        "time", np.float32, DIMENSIONS[0], **COMPRESSION
-    )
-    netcdf_file.createVariable("y", "f4", DIMENSIONS[1], **COMPRESSION)
-    netcdf_file.createVariable("x", "f4", DIMENSIONS[2], **COMPRESSION)
+        "time", "f4", DIMENSIONS[0], **COMPRESSION
+    )  # type: ignore
+    x = netcdf_file.createVariable("y", "f4", DIMENSIONS[1], **COMPRESSION)  # type: ignore
+    y = netcdf_file.createVariable("x", "f4", DIMENSIONS[2], **COMPRESSION)  # type: ignore
 
     time.units = "hours since %s" % start_date.tz_localize(None)
     time.time_zone = str(myawsm.tzinfo).lower()
     time.calendar = "standard"
+
+    y.units = "meters"
+    y.description = "UTM, north south"
+    y.long_name = "y coordinate"
+
+    x.units = "meters"
+    x.description = "UTM, east west"
+    x.long_name = "x coordinate"
 
     netcdf_file.variables["x"][:] = init["x"]
     netcdf_file.variables["y"][:] = init["y"]

--- a/awsm/interface/pysnobal_io.py
+++ b/awsm/interface/pysnobal_io.py
@@ -222,7 +222,7 @@ def output_timestep(s, tstep, options, output_vars):
     # the current time integer
     times = options['output']['snow'].variables['time']
     # offset to match same convention as iSnobal
-    tstep -= pd.to_timedelta(1, unit='h')
+    # tstep -= pd.to_timedelta(1, unit='h')                                 # pk commented this out. correct me if i'm wrong 2022 10 19
     t = nc.date2num(tstep.replace(tzinfo=None), times.units, times.calendar)
 
     if len(times) != 0:

--- a/awsm/interface/pysnobal_io.py
+++ b/awsm/interface/pysnobal_io.py
@@ -98,6 +98,7 @@ def create_variables(
                 "f4",
                 DIMENSIONS,
                 **COMPRESSION,
+                least_significant_digit=4,
             )
             nc_variable.units = variables["units"][index]
             nc_variable.description = variables["description"][index]

--- a/awsm/interface/pysnobal_io.py
+++ b/awsm/interface/pysnobal_io.py
@@ -1,17 +1,18 @@
-import glob
 import os
 from copy import copy
 from datetime import datetime
 
 import netCDF4 as nc
 import numpy as np
-import pandas as pd
 from spatialnc.proj import add_proj
 
 C_TO_K = 273.16
 FREEZE = C_TO_K
+
+
 # Kelvin to Celsius
-def K_TO_C(x): return x - FREEZE
+def K_TO_C(x):
+    return x - FREEZE
 
 
 def output_files(options, init, start_date, myawsm):
@@ -25,158 +26,194 @@ def output_files(options, init, start_date, myawsm):
         myawsm:      awsm class
 
     """
-    fmt = '%Y-%m-%d %H:%M:%S'
+    fmt = "%Y-%m-%d %H:%M:%S"
     # chunk size
     cs = None
 
     # ------------------------------------------------------------------------
     # EM netCDF
     m = {}
-    m['name'] = ['net_rad', 'sensible_heat', 'latent_heat', 'snow_soil',
-                 'precip_advected', 'sum_EB', 'evaporation', 'snowmelt',
-                 'SWI', 'cold_content']
-    m['units'] = ['W m-2', 'W m-2', 'W m-2', 'W m-2', 'W m-2', 'W m-2',
-                  'kg m-2', 'kg m-2', 'kg or mm m-2', 'J m-2']
-    m['description'] = ['Average net all-wave radiation',
-                        'Average sensible heat transfer',
-                        'Average latent heat exchange',
-                        'Average snow/soil heat exchange',
-                        'Average advected heat from precipitation',
-                        'Average sum of EB terms for snowcover',
-                        'Total evaporation',
-                        'Total snowmelt',
-                        'Total runoff',
-                        'Snowcover cold content']
+    m["name"] = [
+        "net_rad",
+        "sensible_heat",
+        "latent_heat",
+        "snow_soil",
+        "precip_advected",
+        "sum_EB",
+        "evaporation",
+        "snowmelt",
+        "SWI",
+        "cold_content",
+    ]
+    m["units"] = [
+        "W m-2",
+        "W m-2",
+        "W m-2",
+        "W m-2",
+        "W m-2",
+        "W m-2",
+        "kg m-2",
+        "kg m-2",
+        "kg or mm m-2",
+        "J m-2",
+    ]
+    m["description"] = [
+        "Average net all-wave radiation",
+        "Average sensible heat transfer",
+        "Average latent heat exchange",
+        "Average snow/soil heat exchange",
+        "Average advected heat from precipitation",
+        "Average sum of EB terms for snowcover",
+        "Total evaporation",
+        "Total snowmelt",
+        "Total runoff",
+        "Snowcover cold content",
+    ]
 
-    emname = myawsm.em_name+'.nc'
-    # if myawsm.restart_run:
-    #     emname = 'em_restart_{}.nc'.format(myawsm.restart_hr)
-    #     start_date = myawsm.restart_date
+    emname = myawsm.em_name + ".nc"
 
-    netcdfFile = os.path.join(options['output']['location'], emname)
+    netcdfFile = os.path.join(options["output"]["location"], emname)
 
     if os.path.isfile(netcdfFile):
         myawsm._logger.warning(
-            'Opening {}, data may be overwritten!'.format(netcdfFile))
-        em = nc.Dataset(netcdfFile, 'a')
-        h = '[{}] Data added or updated'.format(
-            datetime.now().strftime(fmt))
-        setattr(em, 'last_modified', h)
+            "Opening {}, data may be overwritten!".format(netcdfFile)
+        )
+        em = nc.Dataset(netcdfFile, "a")
+        h = "[{}] Data added or updated".format(datetime.now().strftime(fmt))
+        setattr(em, "last_modified", h)
 
-        if 'projection' not in em.variables.keys():
-            em = add_proj(em, None, myawsm.topo.topoConfig['filename'])
+        if "projection" not in em.variables.keys():
+            em = add_proj(em, None, myawsm.topo.topoConfig["filename"])
 
     else:
-        em = nc.Dataset(netcdfFile, 'w')
+        em = nc.Dataset(netcdfFile, "w")
 
-        dimensions = ('time', 'y', 'x')
+        dimensions = ("time", "y", "x")
 
         # create the dimensions
-        em.createDimension('time', None)
-        em.createDimension('y', len(init['y']))
-        em.createDimension('x', len(init['x']))
+        em.createDimension("time", None)
+        em.createDimension("y", len(init["y"]))
+        em.createDimension("x", len(init["x"]))
 
         # create some variables
-        em.createVariable('time', 'f', dimensions[0])
-        em.createVariable('y', 'f', dimensions[1])
-        em.createVariable('x', 'f', dimensions[2])
+        em.createVariable("time", "f", dimensions[0])
+        em.createVariable("y", "f", dimensions[1])
+        em.createVariable("x", "f", dimensions[2])
 
-        # setattr(em.variables['time'], 'units', 'hours since %s' % options['time']['start_date'])
-        setattr(em.variables['time'], 'units',
-                'hours since %s' % start_date.tz_localize(None))
-        setattr(em.variables['time'], 'time_zone', str(myawsm.tzinfo).lower())
-        setattr(em.variables['time'], 'calendar', 'standard')
+        setattr(
+            em.variables["time"],
+            "units",
+            "hours since %s" % start_date.tz_localize(None),
+        )
+        setattr(em.variables["time"], "time_zone", str(myawsm.tzinfo).lower())
+        setattr(em.variables["time"], "calendar", "standard")
         #     setattr(em.variables['time'], 'time_zone', time_zone)
-        em.variables['x'][:] = init['x']
-        em.variables['y'][:] = init['y']
+        em.variables["x"][:] = init["x"]
+        em.variables["y"][:] = init["y"]
 
         # em image
-        for i, v in enumerate(m['name']):
+        for i, v in enumerate(m["name"]):
             # check to see if in output variables
             if v.lower() in myawsm.pysnobal_output_vars:
-                # em.createVariable(v, 'f', dimensions[:3], chunksizes=(6,10,10))
-                em.createVariable(v, 'f', dimensions[:3], chunksizes=cs)
-                setattr(em.variables[v], 'units', m['units'][i])
-                setattr(em.variables[v], 'description', m['description'][i])
+                em.createVariable(v, "f", dimensions[:3], chunksizes=cs)
+                setattr(em.variables[v], "units", m["units"][i])
+                setattr(em.variables[v], "description", m["description"][i])
 
         # add projection info
-        em = add_proj(em, None, myawsm.topo.topoConfig['filename'])
+        em = add_proj(em, None, myawsm.topo.topoConfig["filename"])
 
-    options['output']['em'] = em
+    options["output"]["em"] = em
 
     # ------------------------------------------------------------------------
     # SNOW netCDF
 
     s = {}
-    s['name'] = ['thickness', 'snow_density', 'specific_mass', 'liquid_water',
-                 'temp_surf', 'temp_lower', 'temp_snowcover',
-                 'thickness_lower', 'water_saturation']
-    s['units'] = ['m', 'kg m-3', 'kg m-2', 'kg m-2', 'C',
-                  'C', 'C', 'm', 'percent']
-    s['description'] = ['Predicted thickness of the snowcover',
-                        'Predicted average snow density',
-                        'Predicted specific mass of the snowcover',
-                        'Predicted mass of liquid water in the snowcover',
-                        'Predicted temperature of the surface layer',
-                        'Predicted temperature of the lower layer',
-                        'Predicted temperature of the snowcover',
-                        'Predicted thickness of the lower layer',
-                        'Predicted percentage of liquid water saturation of the snowcover']
+    s["name"] = [
+        "thickness",
+        "snow_density",
+        "specific_mass",
+        "liquid_water",
+        "temp_surf",
+        "temp_lower",
+        "temp_snowcover",
+        "thickness_lower",
+        "water_saturation",
+    ]
+    s["units"] = [
+        "m",
+        "kg m-3",
+        "kg m-2",
+        "kg m-2",
+        "C",
+        "C",
+        "C",
+        "m",
+        "percent",
+    ]
+    s["description"] = [
+        "Predicted thickness of the snowcover",
+        "Predicted average snow density",
+        "Predicted specific mass of the snowcover",
+        "Predicted mass of liquid water in the snowcover",
+        "Predicted temperature of the surface layer",
+        "Predicted temperature of the lower layer",
+        "Predicted temperature of the snowcover",
+        "Predicted thickness of the lower layer",
+        "Predicted percentage of liquid water saturation of the snowcover",
+    ]
 
-    snowname = myawsm.snow_name + '.nc'
-    # if myawsm.restart_run:
-    #     snowname = 'snow_restart_{}.nc'.format(myawsm.restart_hr)
+    snowname = myawsm.snow_name + ".nc"
 
-    netcdfFile = os.path.join(options['output']['location'], snowname)
+    netcdfFile = os.path.join(options["output"]["location"], snowname)
 
     if os.path.isfile(netcdfFile):
         myawsm._logger.warning(
-            'Opening {}, data may be overwritten!'.format(netcdfFile))
-        snow = nc.Dataset(netcdfFile, 'a')
-        h = '[{}] Data added or updated'.format(
-            datetime.now().strftime(fmt))
-        setattr(snow, 'last_modified', h)
+            "Opening {}, data may be overwritten!".format(netcdfFile)
+        )
+        snow = nc.Dataset(netcdfFile, "a")
+        h = "[{}] Data added or updated".format(datetime.now().strftime(fmt))
+        setattr(snow, "last_modified", h)
 
-        if 'projection' not in snow.variables.keys():
-            snow = add_proj(snow, None, myawsm.topo.topoConfig['filename'])
+        if "projection" not in snow.variables.keys():
+            snow = add_proj(snow, None, myawsm.topo.topoConfig["filename"])
 
     else:
-        dimensions = ('time', 'y', 'x')
+        dimensions = ("time", "y", "x")
 
-        snow = nc.Dataset(netcdfFile, 'w')
+        snow = nc.Dataset(netcdfFile, "w")
 
         # create the dimensions
-        snow.createDimension('time', None)
-        snow.createDimension('y', len(init['y']))
-        snow.createDimension('x', len(init['x']))
+        snow.createDimension("time", None)
+        snow.createDimension("y", len(init["y"]))
+        snow.createDimension("x", len(init["x"]))
 
         # create some variables
-        snow.createVariable('time', 'f', dimensions[0])
-        snow.createVariable('y', 'f', dimensions[1])
-        snow.createVariable('x', 'f', dimensions[2])
+        snow.createVariable("time", "f", dimensions[0])
+        snow.createVariable("y", "f", dimensions[1])
+        snow.createVariable("x", "f", dimensions[2])
 
-        setattr(snow.variables['time'], 'units',
-                'hours since %s' % start_date.tz_localize(None))
-        setattr(snow.variables['time'], 'time_zone',
-                str(myawsm.tzinfo).lower())
-        setattr(snow.variables['time'], 'calendar', 'standard')
-        #     setattr(snow.variables['time'], 'time_zone', time_zone)
-        snow.variables['x'][:] = init['x']
-        snow.variables['y'][:] = init['y']
+        setattr(
+            snow.variables["time"],
+            "units",
+            "hours since %s" % start_date.tz_localize(None),
+        )
+        setattr(snow.variables["time"], "time_zone", str(myawsm.tzinfo).lower())
+        setattr(snow.variables["time"], "calendar", "standard")
+        snow.variables["x"][:] = init["x"]
+        snow.variables["y"][:] = init["y"]
 
         # snow image
-        for i, v in enumerate(s['name']):
+        for i, v in enumerate(s["name"]):
             # check to see if in output variables
             if v.lower() in myawsm.pysnobal_output_vars:
-                snow.createVariable(v, 'f', dimensions[:3], chunksizes=cs)
-                # snow.createVariable(v, 'f', dimensions[:3])
-                setattr(snow.variables[v], 'units', s['units'][i])
-                setattr(snow.variables[v], 'description', s['description'][i])
+                snow.createVariable(v, "f", dimensions[:3], chunksizes=cs)
+                setattr(snow.variables[v], "units", s["units"][i])
+                setattr(snow.variables[v], "description", s["description"][i])
 
         # add projection info
-        snow = add_proj(snow, None, myawsm.topo.topoConfig['filename'])
+        snow = add_proj(snow, None, myawsm.topo.topoConfig["filename"])
 
-    options['output']['snow'] = snow
+    options["output"]["snow"] = snow
 
 
 def output_timestep(s, tstep, options, output_vars):
@@ -190,17 +227,29 @@ def output_timestep(s, tstep, options, output_vars):
 
     """
 
-    em_out = {'net_rad': 'R_n_bar', 'sensible_heat': 'H_bar',
-              'latent_heat': 'L_v_E_bar',
-              'snow_soil': 'G_bar', 'precip_advected': 'M_bar',
-              'sum_EB': 'delta_Q_bar', 'evaporation': 'E_s_sum',
-              'snowmelt': 'melt_sum', 'SWI': 'ro_pred_sum',
-              'cold_content': 'cc_s'}
-    snow_out = {'thickness': 'z_s', 'snow_density': 'rho',
-                'specific_mass': 'm_s', 'liquid_water': 'h2o',
-                'temp_surf': 'T_s_0', 'temp_lower': 'T_s_l',
-                'temp_snowcover': 'T_s', 'thickness_lower': 'z_s_l',
-                'water_saturation': 'h2o_sat'}
+    em_out = {
+        "net_rad": "R_n_bar",
+        "sensible_heat": "H_bar",
+        "latent_heat": "L_v_E_bar",
+        "snow_soil": "G_bar",
+        "precip_advected": "M_bar",
+        "sum_EB": "delta_Q_bar",
+        "evaporation": "E_s_sum",
+        "snowmelt": "melt_sum",
+        "SWI": "ro_pred_sum",
+        "cold_content": "cc_s",
+    }
+    snow_out = {
+        "thickness": "z_s",
+        "snow_density": "rho",
+        "specific_mass": "m_s",
+        "liquid_water": "h2o",
+        "temp_surf": "T_s_0",
+        "temp_lower": "T_s_l",
+        "temp_snowcover": "T_s",
+        "thickness_lower": "z_s_l",
+        "water_saturation": "h2o_sat",
+    }
 
     # preallocate
     em = {}
@@ -214,13 +263,12 @@ def output_timestep(s, tstep, options, output_vars):
         snow[key] = copy(s[value])
 
     # convert from K to C
-    snow['temp_snowcover'] -= FREEZE
-    snow['temp_surf'] -= FREEZE
-    snow['temp_lower'] -= FREEZE
+    snow["temp_snowcover"] -= FREEZE
+    snow["temp_surf"] -= FREEZE
+    snow["temp_lower"] -= FREEZE
 
-    # now find the correct index
     # the current time integer
-    times = options['output']['snow'].variables['time']
+    times = options["output"]["snow"].variables["time"]
     # offset to match same convention as iSnobal
     # tstep -= pd.to_timedelta(1, unit='h')                                 # pk commented this out. correct me if i'm wrong 2022 10 19
     t = nc.date2num(tstep.replace(tzinfo=None), times.units, times.calendar)
@@ -235,17 +283,17 @@ def output_timestep(s, tstep, options, output_vars):
         index = len(times)
 
     # insert the time
-    options['output']['snow'].variables['time'][index] = t
-    options['output']['em'].variables['time'][index] = t
+    options["output"]["snow"].variables["time"][index] = t
+    options["output"]["em"].variables["time"][index] = t
 
     # insert the data
     for key in em_out:
         if key.lower() in output_vars:
-            options['output']['em'].variables[key][index, :] = em[key]
+            options["output"]["em"].variables[key][index, :] = em[key]
     for key in snow_out:
         if key.lower() in output_vars:
-            options['output']['snow'].variables[key][index, :] = snow[key]
+            options["output"]["snow"].variables[key][index, :] = snow[key]
 
     # sync to disk
-    options['output']['snow'].sync()
-    options['output']['em'].sync()
+    options["output"]["snow"].sync()
+    options["output"]["em"].sync()

--- a/awsm/interface/pysnobal_io.py
+++ b/awsm/interface/pysnobal_io.py
@@ -8,7 +8,7 @@ import numpy as np
 from spatialnc.proj import add_proj
 
 # NetCDF file parameters
-COMPRESSION = dict(zlib=True, complevel=4)
+COMPRESSION = dict(compression="zlib", complevel=4)
 DIMENSIONS = ("time", "y", "x")
 
 C_TO_K = 273.16
@@ -92,7 +92,7 @@ def create_variables(netcdf_file: nc.Dataset, variables: dict, myawsm):
                 DIMENSIONS,
                 **COMPRESSION,
                 least_significant_digit=4,
-            )
+            )  # type: ignore
             nc_variable.units = variables["units"][index]
             nc_variable.description = variables["description"][index]
 

--- a/awsm/interface/pysnobal_io.py
+++ b/awsm/interface/pysnobal_io.py
@@ -70,9 +70,7 @@ def create_netCDF(
     return netcdf_file
 
 
-def create_variables(
-    netcdf_file: nc.Dataset, variables: dict, myawsm
-) -> nc.Dataset:
+def create_variables(netcdf_file: nc.Dataset, variables: dict, myawsm):
     """
     Create NetCDF variables with units and description
 
@@ -84,11 +82,6 @@ def create_variables(
         Variable information. Needs keys for name, units ,and description
     myawsm : AWSM
         AWSM instance
-
-    Returns
-    -------
-    nc.Dataset
-        NetCDF file with added variables
     """
     for index, variable in enumerate(variables["name"]):
         # check to see if in output variables

--- a/awsm/interface/pysnobal_io.py
+++ b/awsm/interface/pysnobal_io.py
@@ -8,7 +8,7 @@ import numpy as np
 from spatialnc.proj import add_proj
 
 # NetCDF file parameters
-COMPRESSION = dict(zlib=True, complevel=5)
+COMPRESSION = dict(zlib=True, complevel=4)
 DIMENSIONS = ("time", "y", "x")
 
 C_TO_K = 273.16

--- a/awsm/interface/smrf_connector.py
+++ b/awsm/interface/smrf_connector.py
@@ -86,14 +86,17 @@ class SMRFConnector():
 
         self.force = {}
         for variable in self.MAP_INPUTS.keys():
-            try:
-                self.force[variable] = nc.Dataset(
-                    os.path.join(self.output_path, '{}.nc'.format(variable)),
-                    'r')
 
-            except FileNotFoundError:
+            # Soil temperature is a constant value defined in the .ini file
+            if variable == 'soil_temp':
                 self.force['soil_temp'] = float(self.myawsm.soil_temp) * \
                     np.ones_like(self.myawsm.topo.dem)
+                continue
+
+            self.force[variable] = nc.Dataset(
+                os.path.join(self.output_path, '{}.nc'.format(variable)),
+                'r'
+            )
 
     def close_netcdf_files(self):
         """
@@ -110,7 +113,6 @@ class SMRFConnector():
         place that time step into a dict
 
         Args:
-            force:   input array of forcing variables
             tstep:   datetime time step
 
         Returns:

--- a/awsm/tests/awsm_test_case.py
+++ b/awsm/tests/awsm_test_case.py
@@ -167,21 +167,26 @@ class AWSMTestCase(unittest.TestCase):
         # just compare the variable desired with time,x,y
         variables = ['time', 'x', 'y', variable]
         for var_name in variables:
+            # Check attribute existance
+            assert var_name in test.variables, (
+                f"Variable: {var_name} not found in test output file"
+            )
 
             # compare the dimensions
-            for att in gold.variables[var_name].ncattrs():
-                self.assertEqual(
-                    getattr(gold.variables[var_name], att),
-                    getattr(test.variables[var_name], att))
+            self.assertEqual(
+                gold.variables[var_name].ncattrs(),
+                test.variables[var_name].ncattrs(),
+                "Missing variable attribute. "
+                f" Gold: {gold.variables[var_name].ncattrs()}"
+                f" Test: {test.variables[var_name].ncattrs()}",
+            )
 
             # only compare those that are floats
-            if gold.variables[var_name].datatype != np.dtype('S1'):
-                error_msg = "Variable: {0} did not match gold standard". \
-                    format(var_name)
+            if gold.variables[var_name].datatype != np.dtype("S1"):
                 self.assert_gold_equal(
                     gold.variables[var_name][:],
                     test.variables[var_name][:],
-                    error_msg
+                    f"Variable: {var_name} did not match gold standard",
                 )
 
         gold.close()

--- a/awsm/tests/awsm_test_case.py
+++ b/awsm/tests/awsm_test_case.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import shutil
 import unittest
@@ -141,13 +140,6 @@ class AWSMTestCase(unittest.TestCase):
 
     def setUp(self):
         self._dist_variables = None
-
-        # clear the logger
-        for handler in logging.root.handlers:
-            logging.root.removeHandler(handler)
-
-    def tearDown(self):
-        logging.shutdown()
 
     def compare_hrrr_gold(self):
         """

--- a/awsm/tests/awsm_test_case.py
+++ b/awsm/tests/awsm_test_case.py
@@ -56,7 +56,8 @@ class AWSMTestCase(unittest.TestCase):
     @classmethod
     def load_base_config(cls):
         cls._base_config = get_user_config(
-            cls.config_file, modules=['smrf', 'awsm'])
+            cls.config_file, modules=['smrf', 'awsm']
+        )
 
     @classmethod
     def configure(cls):

--- a/awsm/tests/framework/test_ipysnobal.py
+++ b/awsm/tests/framework/test_ipysnobal.py
@@ -1,0 +1,139 @@
+from unittest.mock import MagicMock, call, patch
+
+import pandas as pd
+from inicheck.tools import cast_all_variables
+
+import awsm
+from awsm.framework.framework import AWSM
+from awsm.interface.ipysnobal import PySnobal
+from awsm.tests.awsm_test_case_lakes import AWSMTestCaseLakes
+
+
+class TestPySnobal(AWSMTestCaseLakes):
+    """
+    Testing using Lakes:
+        - ipysnobal
+        - initialize from init.nc file
+        - loading from netcdf
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        config = self.base_config_copy()
+
+        config.raw_cfg['time']['start_date'] = '2019-10-01 00:00'
+        config.raw_cfg['files']['init_type'] = 'netcdf'
+
+        config.apply_recipes()
+        run_config = cast_all_variables(config, config.mcfg)
+        awsm = AWSM(run_config, testing=True)
+        self.subject = PySnobal(awsm)
+        self.subject.initialize_ipysnobal()
+
+    @patch('netCDF4.Dataset')
+    @patch('awsm.interface.ipysnobal.SMRFConnector')
+    @patch('copy.deepcopy')
+    def test_load_previous_day_attributes(
+        self, mock_copy, mock_smrf, _mock_nc_file
+    ):
+        awsm_copy = MagicMock()
+        mock_copy.return_value = awsm_copy
+
+        self.subject.load_previous_day()
+
+        # Comparing the str here since the AWSM time is created via pandas
+        # date_range and has an 'freq' attribute
+        previous_day = str(pd.Timestamp("2019-09-30 23:00:00+0000"))
+
+        assert str(awsm_copy.start_date) == previous_day
+        assert str(awsm_copy.end_date) == previous_day
+        assert call.set_path_output() in awsm_copy.method_calls
+        mock_smrf.assert_called_once_with(awsm_copy)
+
+    @patch.object(awsm.interface.smrf_connector.SMRFConnector, 'get_timestep_netcdf')
+    @patch('netCDF4.Dataset')
+    def test_load_previous_day_file_loading(self, mock_nc_file, _mock_smrf):
+        self.subject.load_previous_day()
+        # Grab the last two path elements for each openend file
+        opened_files = [
+            '/'.join(file[0][0].rsplit('/', 2)[-2:])
+            for file in mock_nc_file.call_args_list
+        ]
+        previous_day = '20190930'
+
+        for forcing_data in PySnobal.FORCING_VARIABLES:
+            if forcing_data == 'soil_temp':
+                # Soil temperature is a constant value, not a file
+                continue
+            file_path = f"run{previous_day}_{previous_day}/{forcing_data}.nc"
+            assert file_path in opened_files, \
+                f"File {file_path} not found in opened files: {opened_files}"
+
+    @patch('netCDF4.Dataset')
+    @patch.object(awsm.interface.ipysnobal.SMRFConnector, 'get_timestep_netcdf')
+    def test_load_previous_day_data_loading(
+        self, mock_smrf_connector, _mock_nc_file
+    ):
+        mock_data = MagicMock()
+        mock_smrf_connector.return_value = mock_data
+
+        self.subject.load_previous_day()
+
+        assert str(mock_smrf_connector.call_args[0][0]) == (
+            str(pd.Timestamp("2019-09-30 23:00:00+0000"))
+        )
+        assert self.subject.input1 == mock_data
+
+    @patch('netCDF4.Dataset')
+    @patch.object(awsm.interface.ipysnobal.SMRFConnector, 'get_timestep_netcdf')
+    @patch.object(awsm.interface.ipysnobal.PySnobal, 'convert_temperatures')
+    def test_load_previous_day_temperature_convert(
+        self, mock_temperature, mock_smrf_connector, _mock_nc_file
+    ):
+        mock_data = MagicMock()
+        mock_smrf_connector.return_value = mock_data
+
+        self.subject.load_previous_day()
+
+        mock_temperature.assert_called_once_with(mock_data)
+
+
+    @patch('awsm.interface.ipysnobal.SMRFConnector')
+    def test_load_previous_day_file_close(self, mock_smrf_connector):
+        self.subject.load_previous_day()
+
+        assert call().close_netcdf_files() in mock_smrf_connector.mock_calls
+
+    @patch.object(awsm.interface.ipysnobal.PySnobal, 'load_previous_day')
+    def test_load_first_timestep_inputs_previous_day(self, mock_load_day):
+        self.subject.date_time = [
+            pd.Timestamp('2019-10-01 00:00')
+        ]
+        self.subject.awsm.model_init.init_file = MagicMock()
+
+        self.subject.load_first_timestep_inputs()
+
+        mock_load_day.assert_called_once()
+
+    @patch.object(awsm.interface.ipysnobal.PySnobal, 'get_timestep_inputs')
+    def test_load_first_timestep_inputs_first_timestep(self, mock_timestamp):
+        self.subject.date_time = [
+            pd.Timestamp('2019-10-01 00:00')
+        ]
+        self.subject.awsm.model_init.init_file = None
+
+        self.subject.load_first_timestep_inputs()
+
+        mock_timestamp.assert_called_once()
+
+    @patch.object(awsm.interface.ipysnobal.PySnobal, 'get_timestep_inputs')
+    def test_load_first_timestep_inputs_non_zero_hour(self, mock_timestamp):
+        self.subject.date_time = [
+            pd.Timestamp('2019-10-01 06:00')
+        ]
+        self.subject.awsm.model_init.init_file = MagicMock()
+
+        self.subject.load_first_timestep_inputs()
+
+        mock_timestamp.assert_called_once()

--- a/awsm/tests/framework/test_ipysnobal.py
+++ b/awsm/tests/framework/test_ipysnobal.py
@@ -128,9 +128,12 @@ class TestPySnobal(AWSMTestCaseLakes):
         ]
         self.subject.awsm.model_init.init_file = None
 
+        assert len(self.subject.date_time) == 1
+
         self.subject.load_first_timestep_inputs()
 
         mock_timestamp.assert_called_once()
+        assert len(self.subject.date_time) == 0
 
     @patch("netCDF4.Dataset")
     @patch.object(awsm.interface.ipysnobal.PySnobal, "get_timestep_inputs")
@@ -142,6 +145,9 @@ class TestPySnobal(AWSMTestCaseLakes):
         ]
         self.subject.awsm.model_init.init_file = MagicMock()
 
+        assert len(self.subject.date_time) == 1
+
         self.subject.load_first_timestep_inputs()
 
         mock_timestamp.assert_called_once()
+        assert len(self.subject.date_time) == 0

--- a/awsm/tests/framework/test_ipysnobal.py
+++ b/awsm/tests/framework/test_ipysnobal.py
@@ -31,12 +31,9 @@ class TestPySnobal(AWSMTestCaseLakes):
         self.subject = PySnobal(awsm)
         self.subject.initialize_ipysnobal()
 
-    @patch('netCDF4.Dataset')
-    @patch('awsm.interface.ipysnobal.SMRFConnector')
-    @patch('copy.deepcopy')
-    def test_load_previous_day_attributes(
-        self, mock_copy, mock_smrf, _mock_nc_file
-    ):
+    @patch("awsm.interface.ipysnobal.SMRFConnector")
+    @patch("copy.deepcopy")
+    def test_load_previous_day_attributes(self, mock_copy, mock_smrf):
         awsm_copy = MagicMock()
         mock_copy.return_value = awsm_copy
 
@@ -51,24 +48,28 @@ class TestPySnobal(AWSMTestCaseLakes):
         assert call.set_path_output() in awsm_copy.method_calls
         mock_smrf.assert_called_once_with(awsm_copy)
 
-    @patch.object(awsm.interface.smrf_connector.SMRFConnector, 'get_timestep_netcdf')
-    @patch('netCDF4.Dataset')
+    @patch.object(
+        awsm.interface.smrf_connector.SMRFConnector, "get_timestep_netcdf"
+    )
+    @patch("netCDF4.Dataset")
     def test_load_previous_day_file_loading(self, mock_nc_file, _mock_smrf):
         self.subject.load_previous_day()
         # Grab the last two path elements for each openend file
         opened_files = [
-            '/'.join(file[0][0].rsplit('/', 2)[-2:])
+            "/".join(file[0][0].rsplit("/", 2)[-2:])
             for file in mock_nc_file.call_args_list
         ]
-        previous_day = '20190930'
+        previous_day = "20190930"
 
         for forcing_data in PySnobal.FORCING_VARIABLES:
-            if forcing_data == 'soil_temp':
+            if forcing_data == "soil_temp":
                 # Soil temperature is a constant value, not a file
                 continue
+
             file_path = f"run{previous_day}_{previous_day}/{forcing_data}.nc"
-            assert file_path in opened_files, \
+            assert file_path in opened_files, (
                 f"File {file_path} not found in opened files: {opened_files}"
+            )
 
     @patch("netCDF4.Dataset")
     @patch.object(awsm.interface.ipysnobal.SMRFConnector, "get_timestep_netcdf")

--- a/awsm/tests/framework/test_ipysnobal.py
+++ b/awsm/tests/framework/test_ipysnobal.py
@@ -70,8 +70,8 @@ class TestPySnobal(AWSMTestCaseLakes):
             assert file_path in opened_files, \
                 f"File {file_path} not found in opened files: {opened_files}"
 
-    @patch('netCDF4.Dataset')
-    @patch.object(awsm.interface.ipysnobal.SMRFConnector, 'get_timestep_netcdf')
+    @patch("netCDF4.Dataset")
+    @patch.object(awsm.interface.ipysnobal.SMRFConnector, "get_timestep_netcdf")
     def test_load_previous_day_data_loading(
         self, mock_smrf_connector, _mock_nc_file
     ):
@@ -85,9 +85,9 @@ class TestPySnobal(AWSMTestCaseLakes):
         )
         assert self.subject.input1 == mock_data
 
-    @patch('netCDF4.Dataset')
-    @patch.object(awsm.interface.ipysnobal.SMRFConnector, 'get_timestep_netcdf')
-    @patch.object(awsm.interface.ipysnobal.PySnobal, 'convert_temperatures')
+    @patch("netCDF4.Dataset")
+    @patch.object(awsm.interface.ipysnobal.SMRFConnector, "get_timestep_netcdf")
+    @patch.object(awsm.interface.ipysnobal.PySnobal, "convert_temperatures")
     def test_load_previous_day_temperature_convert(
         self, mock_temperature, mock_smrf_connector, _mock_nc_file
     ):
@@ -98,15 +98,17 @@ class TestPySnobal(AWSMTestCaseLakes):
 
         mock_temperature.assert_called_once_with(mock_data)
 
-
     @patch('awsm.interface.ipysnobal.SMRFConnector')
     def test_load_previous_day_file_close(self, mock_smrf_connector):
         self.subject.load_previous_day()
 
         assert call().close_netcdf_files() in mock_smrf_connector.mock_calls
 
-    @patch.object(awsm.interface.ipysnobal.PySnobal, 'load_previous_day')
-    def test_load_first_timestep_inputs_previous_day(self, mock_load_day):
+    @patch("netCDF4.Dataset")
+    @patch.object(awsm.interface.ipysnobal.PySnobal, "load_previous_day")
+    def test_load_first_timestep_inputs_previous_day(
+        self, mock_load_day, _mock_nc
+    ):
         self.subject.date_time = [
             pd.Timestamp('2019-10-01 00:00')
         ]
@@ -116,8 +118,11 @@ class TestPySnobal(AWSMTestCaseLakes):
 
         mock_load_day.assert_called_once()
 
-    @patch.object(awsm.interface.ipysnobal.PySnobal, 'get_timestep_inputs')
-    def test_load_first_timestep_inputs_first_timestep(self, mock_timestamp):
+    @patch("netCDF4.Dataset")
+    @patch.object(awsm.interface.ipysnobal.PySnobal, "get_timestep_inputs")
+    def test_load_first_timestep_inputs_first_timestep(
+        self, mock_timestamp, _mock_nc
+    ):
         self.subject.date_time = [
             pd.Timestamp('2019-10-01 00:00')
         ]
@@ -127,8 +132,11 @@ class TestPySnobal(AWSMTestCaseLakes):
 
         mock_timestamp.assert_called_once()
 
-    @patch.object(awsm.interface.ipysnobal.PySnobal, 'get_timestep_inputs')
-    def test_load_first_timestep_inputs_non_zero_hour(self, mock_timestamp):
+    @patch("netCDF4.Dataset")
+    @patch.object(awsm.interface.ipysnobal.PySnobal, "get_timestep_inputs")
+    def test_load_first_timestep_inputs_non_zero_hour(
+        self, mock_timestamp, _mock_nc
+    ):
         self.subject.date_time = [
             pd.Timestamp('2019-10-01 06:00')
         ]

--- a/awsm/tests/framework/test_ipysnobal.py
+++ b/awsm/tests/framework/test_ipysnobal.py
@@ -20,15 +20,13 @@ class TestPySnobal(AWSMTestCaseLakes):
     def setUp(self):
         super().setUp()
 
-        config = self.base_config_copy()
+        self.run_config.raw_cfg['time']['start_date'] = '2019-10-01 00:00'
+        self.run_config.raw_cfg['files']['init_type'] = 'netcdf'
 
-        config.raw_cfg['time']['start_date'] = '2019-10-01 00:00'
-        config.raw_cfg['files']['init_type'] = 'netcdf'
-
-        config.apply_recipes()
-        run_config = cast_all_variables(config, config.mcfg)
-        awsm = AWSM(run_config, testing=True)
-        self.subject = PySnobal(awsm)
+        self.run_config.apply_recipes()
+        run_config = cast_all_variables(self.run_config, self.run_config.mcfg)
+        awsm_run = AWSM(run_config, testing=True)
+        self.subject = PySnobal(awsm_run)
         self.subject.initialize_ipysnobal()
 
     @patch("awsm.interface.ipysnobal.SMRFConnector")


### PR DESCRIPTION
This PR fixes and adds the following:
* Properly simulate 24 hours. Previously AWSM used the 00 hour to initialize the forcing and interpolate those to the next hour (01). This resulted in cutting the day short of an hour and only simulate 23 hours. Now the initialization at the 00 hour looks back to the previous day 23 hour and uses that as the starting point.
* Change logic to determine whether an hour needs to be save based on the time stamp and not the index of the for loop, processing all hours
* Add zlib level 4 compression to the `snow.nc` and `em.nc`
* Truncate saved significant digits to four in `snow.nc` and `em.nc`
* Remove any previously exisiting `snow.nc` and `em.nc` when restarting and don't try to overwrite them. The latter attempt has been flaky and caused the model to crash.

**NOTE**:
The `snow.nc` and `em.nc` now will always have two timestamps when setting the output to every 24-hours. This will be the 00 hour as the snow/em state at midnight and the 23 hour to save the last state of the snow pack of the day and use that to initialize the next day.